### PR TITLE
Update uuid to version 3.0.0

### DIFF
--- a/lib/proxy_amqp.js
+++ b/lib/proxy_amqp.js
@@ -26,7 +26,7 @@ limitations under the License.
 var caf_core = require('caf_core');
 var caf_comp = caf_core.caf_components;
 var genProxy = caf_comp.gen_proxy;
-var uuid = require('node-uuid').v4;
+var uuid = require('uuid').v4;
 
 /**
  * Factory method to interact with a external message queue.

--- a/package.json
+++ b/package.json
@@ -1,27 +1,29 @@
 {
-    "name": "caf_amqp",
-    "description": "Cloud Assistant library to use a reliable message queue",
-    "version": "0.2.5",
-    "author": "Antonio Lain <antlai@cafjs.com>",
-    "dependencies": {
-        "caf_core": "^0.2.0",
-        "amqp": "^0.2.4",
-        "node-uuid" : ">=1.4.2"
-    },
-    "devDependencies": {
-        "eslint": "^3.1.1",
-        "nodeunit" : ">=0.9"
-    },
-    "main": "index",
-    "homepage": "http://www.cafjs.com",
-    "repository": {
-        "type": "git",
-        "url": "https://github.com/cafjs/caf_amqp.git"
-    },
-    "scripts": {
-        "test": "node ./node_modules/.bin/nodeunit",
-        "eslint" : "./node_modules/.bin/eslint .",
-        "eslintfix" : "./node_modules/.bin/eslint --fix ."
-    },
-    "engines": { "node": ">= 0.10.1 " }
+  "name": "caf_amqp",
+  "description": "Cloud Assistant library to use a reliable message queue",
+  "version": "0.2.5",
+  "author": "Antonio Lain <antlai@cafjs.com>",
+  "dependencies": {
+    "amqp": "^0.2.4",
+    "caf_core": "^0.2.0",
+    "uuid": "^3.0.0"
+  },
+  "devDependencies": {
+    "eslint": "^3.1.1",
+    "nodeunit": ">=0.9"
+  },
+  "main": "index",
+  "homepage": "http://www.cafjs.com",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/cafjs/caf_amqp.git"
+  },
+  "scripts": {
+    "test": "node ./node_modules/.bin/nodeunit",
+    "eslint": "./node_modules/.bin/eslint .",
+    "eslintfix": "./node_modules/.bin/eslint --fix ."
+  },
+  "engines": {
+    "node": ">= 0.10.1 "
+  }
 }


### PR DESCRIPTION
## Version 3.0.0 of [uuid](https://github.com/kelektiv/node-uuid) just got published.

Hi there,

This week a new version of the [uuid](https://github.com/kelektiv/node-uuid) module got released. The old module which was available by the name [node-uuid](https://www.npmjs.com/package/node-uuid) got deprecated and will show error message upon every install of the module.

To get rid of those install errors I've created this **automated pull request**. I've run some checks against your code base to test whether you're using one of the [deprecated apis](https://github.com/kelektiv/node-uuid/commit/5ae7287fc935eb55ef39133e4be17ef623ca000e), but this isn't the case.


Please test the changes against your code. I didn't run any tests and therefore can't guarantee that it isn't breaking. You can also just close this pr if you don't want to update your module.

In case there's already another pr open to upgrade uuid, I'm sorry for the effort I'm causing.